### PR TITLE
replace double__underscore

### DIFF
--- a/hub2labhook/pipeline.py
+++ b/hub2labhook/pipeline.py
@@ -135,7 +135,7 @@ class Pipeline(object):
         gitlab_endpoint = content['variables'].get('GITLAB_URL', None)
         self.gitlab = GitlabClient(gitlab_endpoint)
 
-        ci_project = self.gitlab.initialize_project(gevent.repo.replace("/", "__"), namespace)
+        ci_project = self.gitlab.initialize_project(gevent.repo.replace("/", "."), namespace)
 
         # @Todo(ant31) check if clone_url is required
         # clone_url = clone_url_with_auth(gevent.clone_url, "bot:%s" % self.github.token)


### PR DESCRIPTION
The double underscore `__` breaks gitlab registry, causing it to throw a
500 error. Replaced the double underscore with dot `.`.